### PR TITLE
docs: add lesson guides for initial setup and base layout

### DIFF
--- a/lessons/01-kickstart-astro-workspace.md
+++ b/lessons/01-kickstart-astro-workspace.md
@@ -1,0 +1,24 @@
+# Lesson 01：啟動 Astro 工作區
+
+> 聚焦把空的資料夾變成可以運行的 Astro 專案，奠定後續課程的環境基礎。
+
+## 本次新增的檔案
+- `package.json`：建立 `astro`、`@astrojs/check`、`typescript` 的開發依賴，並提供 `dev`、`build`、`check` 等腳本。
+- `astro.config.mjs`：透過 `defineConfig` 指定 `srcDir` 與 `publicDir`，同時允許本機網路上的其他裝置存取開發伺服器。
+- `tsconfig.json`：啟用 Astro 推薦的嚴格型別設定，並加入 `~/` 開頭的路徑別名，讓元件引用更簡潔。
+- `src/pages/index.astro`：放入第一個頁面，稍後課程會持續在此頁串接新的版型。
+- `src/styles/main.css`：集中控制版面的背景、字體與 hero 區塊樣式，確保初始化畫面有一致的外觀。
+
+## 關鍵程式區塊
+- `src/pages/index.astro` 中的 `lessons` 陣列：示範如何在 Astro 中混用 JavaScript 與模板，渲染出「接下來要學的項目」清單。
+- `BaseLayout` 匯入 `main.css`：讓全站共享同一套基礎樣式，不必在各頁面重複載入。
+- `package.json` 的 `check` 指令：日後每個 lesson 完成後都可以執行 `pnpm check` 做靜態檢查，提早發現錯誤。
+
+## 現在可以做什麼
+- 在專案根目錄執行 `pnpm install` 安裝依賴，接著用 `pnpm dev` 啟動開發伺服器。
+- 修改 `src/pages/index.astro` 或 `src/styles/main.css`，瀏覽器會立即熱更新，方便練習版面調整。
+- 把 `development.md` 當成學習地圖，每完成一項就更新狀態，累積學習足跡。
+
+## 下一步建議
+- 讀一遍 `references/astro-antfustyle-theme` 的資料夾結構，熟悉之後要重現的功能長什麼樣子。
+- 準備建立共用版型與 `<head>` 中的 SEO 標籤，這會是 Lesson 02 的主軸。

--- a/lessons/02-base-layout-and-head-metadata.md
+++ b/lessons/02-base-layout-and-head-metadata.md
@@ -1,0 +1,22 @@
+# Lesson 02：建立 Base Layout 與 Head 中繼資料
+
+> 讓每個頁面都能共享同一個版型與 SEO 設定，準備好往內容頁擴充。
+
+## 本次新增的檔案
+- `src/layouts/BaseLayout.astro`：包住 `<html>` 骨架、跳到主內容的無障礙連結，以及主要 `<main>` 容器。
+- `src/components/base/Head.astro`：集中處理標題、描述、Open Graph、Twitter Card 等中繼資料。
+- `src/components/base/Footer.astro`：產生年度會自動更新的頁尾，並附上參考主題的連結。
+
+## 關鍵程式區塊
+- BaseLayout 內的 `<style is:global>`：快速放入全域樣式（例如 Skip Link、Footer 間距），後續可視需要拆到獨立 CSS。
+- `<Head>` 元件中的 `pageTitle` 與 `pageDescription`：示範如何根據傳入的 `title`、`description` props 動態組合文字。
+- `canonicalURL`、`og:type`、`article:published_time`：提前預留文章頁會用到的欄位，未來只要傳入對應資料就能啟用。
+
+## 現在可以做什麼
+- 在任何頁面中 `import BaseLayout`，包住內容即可自動套用 Head、Footer 與 Skip Link。
+- 傳入 `title`、`description`、`pubDate`、`lastModDate` 等 props，`Head.astro` 會自動補齊 SEO 與社群分享標籤。
+- 自訂 Footer 文字或連結，讓作品隨著個人品牌更新而調整。
+
+## 下一步建議
+- 開始規劃導覽列與站內設定檔（Lesson 03），讓 BaseLayout 能顯示真正的導覽內容。
+- 思考要把全域樣式拆分到 `src/styles/page.css` 或其他檔案，以便後續維護。


### PR DESCRIPTION
## Summary
- create a `lessons/` directory for step-by-step study notes
- document the files, key code blocks, and capabilities covered in lessons 1 and 2

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cd8b824d60832ebf18fb81a4cd8c39