### PR TITLE
fix: center category filter on timeline axis

### DIFF
--- a/src/styles/timeline.css
+++ b/src/styles/timeline.css
@@ -14,6 +14,7 @@
    ======================== */
 
 .timeline-section {
+  --line-pos: 45%;
   padding-block: 1rem 2rem;
 }
 
@@ -30,6 +31,13 @@
   gap: 0.5rem;
   justify-content: center;
   margin-block-end: 2rem;
+  padding-right: calc((50% - var(--line-pos)) * 2);
+}
+
+@media (max-width: 767px) {
+  .category-filter {
+    padding-right: 0;
+  }
 }
 
 .filter-btn {
@@ -69,9 +77,6 @@
    Timeline structure
    ======================== */
 
-.timeline {
-  --line-pos: 45%;
-}
 
 /* Year group */
 
@@ -291,7 +296,7 @@
    ======================== */
 
 @media (max-width: 767px) {
-  .timeline {
+  .timeline-section {
     --line-pos: 1.5rem;
   }
 


### PR DESCRIPTION
將 --line-pos 自訂屬性從 .timeline 提升至 .timeline-section， 讓 .category-filter 能存取時間軸位置。
桌面版加上 padding-right 偏移，使分類按鈕以時間軸為中心對齊；
手機版維持原本的置中行為。

https://claude.ai/code/session_01H5e45KMaSpCc9UuEYmbEkb